### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 A Model Context Protocol (MCP) server for interacting with the Strava API.
 
+<a href="https://glama.ai/mcp/servers/@yorrickjansen/strava-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@yorrickjansen/strava-mcp/badge" alt="Strava Server MCP server" />
+</a>
+
 ## User Guide
 
 ### Installation


### PR DESCRIPTION
This PR adds a badge for the [Strava MCP Server](https://glama.ai/mcp/servers/@yorrickjansen/strava-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@yorrickjansen/strava-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@yorrickjansen/strava-mcp/badge" alt="Strava Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.